### PR TITLE
infra.yaml: Do not force monitoring and logging systems

### DIFF
--- a/example.yml
+++ b/example.yml
@@ -1,4 +1,19 @@
 infra: 3nodes
+profiles:
+  install-server:
+    steps:
+      1:
+        roles:
+          - cloud::logging::server
+          - cloud::monitoring::server::sensu
+  openstack-full:
+    steps:
+      1:
+        roles:
+          - cloud::logging::agent
+      3:
+        roles:
+          - cloud::monitoring::agent::sensu
 hosts:
   install-server:
     profile: install-server

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -6,11 +6,6 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
-    steps:
-      1:
-        roles:
-          - cloud::logging::server
-          - cloud::monitoring::server::sensu
   openstack-full:
     arity: 3
     edeploy: openstack-full
@@ -23,7 +18,6 @@ profiles:
           - cloud::cache
           - cloud::storage::rbd::monitor
           - cloud::storage::rbd::key
-          - cloud::logging::agent
       2:
         roles:
           - cloud::loadbalancer
@@ -34,7 +28,6 @@ profiles:
         roles:
           - cloud::identity
           - cloud::storage::rbd::pools
-          - cloud::monitoring::agent::sensu
       4:
         roles:
           - cloud::compute::api
@@ -107,7 +100,3 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::logging::agent: logging_agent
-  cloud::logging::server: logging_server
-  cloud::monitoring::agent: monitoring_agent
-  cloud::monitoring::server: monitoring_server

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -3,24 +3,13 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
-    steps:
-      1:
-        roles:
-          - cloud::logging::server
-          - cloud::monitoring::server::sensu
   load-balancer:
     arity: 2+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud::logging::agent
       2:
         roles:
           - cloud::loadbalancer
-      3:
-        roles:
-          - cloud::monitoring::agent::sensu
     serverspec_config:
       ks_user_name: ks_admin_tenant
       ks_user_password: ks_admin_password
@@ -49,14 +38,12 @@ profiles:
           - cloud::cache
           - cloud::storage::rbd::monitor
           - cloud::storage::rbd::key
-          - cloud::logging::agent
       2:
         roles:
           - cloud::dashboard
       3:
         roles:
           - cloud::identity
-          - cloud::monitoring::agent::sensu
       4:
         roles:
           - cloud::compute::api
@@ -111,12 +98,6 @@ profiles:
     arity: 1+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud::logging::agent
-      3:
-        roles:
-          - cloud::monitoring::agent::sensu
       4:
         roles:
           - cloud::compute::hypervisor
@@ -140,9 +121,6 @@ profiles:
     arity: 3+2n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud::logging::agent
       2:
         roles:
           - cloud::storage::rbd::osd
@@ -150,7 +128,6 @@ profiles:
       3:
         roles:
           - cloud::storage::rbd::pools
-          - cloud::monitoring::agent::sensu
     serverspec_config:
       ks_user_name: ks_admin_tenant
       ks_user_password: ks_admin_password
@@ -190,7 +167,3 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::logging::agent: logging_agent
-  cloud::logging::server: logging_server
-  cloud::monitoring::agent: monitoring_agent
-  cloud::monitoring::server: monitoring_server


### PR DESCRIPTION
Currently logging and monitoring solutions were forced in the
infra.yaml file, it is now up to the deployer to specify in its
environment file which solutions one wants to implement.

Close #5 
