### PR TITLE
ref-arch, 3nodes: Force cloud class to step 1 of every profile

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -763,6 +763,3 @@ rsyslog::client::server: {{ config.syslog_server }}
 
 # HAproxy
 haproxy_auth: {{ config.haproxy_auth | default('admin:changeme') }}
-
-classes:
-  - cloud

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -6,12 +6,17 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+    steps:
+      1:
+        roles:
+          - cloud
   openstack-full:
     arity: 3
     edeploy: openstack-full
     steps:
       1:
         roles:
+          - cloud
           - cloud::database::sql
           - cloud::database::nosql
           - cloud::messaging

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -3,10 +3,17 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+    steps:
+      1:
+        roles:
+          - cloud
   load-balancer:
     arity: 2+n
     edeploy: openstack-full
     steps:
+      1:
+        roles:
+          - cloud
       2:
         roles:
           - cloud::loadbalancer
@@ -32,6 +39,7 @@ profiles:
     steps:
       1:
         roles:
+          - cloud
           - cloud::database::sql
           - cloud::database::nosql
           - cloud::messaging
@@ -98,6 +106,9 @@ profiles:
     arity: 1+n
     edeploy: openstack-full
     steps:
+      1:
+        roles:
+          - cloud
       4:
         roles:
           - cloud::compute::hypervisor
@@ -121,6 +132,9 @@ profiles:
     arity: 3+2n
     edeploy: openstack-full
     steps:
+      1:
+        roles:
+          - cloud
       2:
         roles:
           - cloud::storage::rbd::osd


### PR DESCRIPTION
The cloud class is common to every node, it needs to happen at step1.
The way it was done before was functional, but could leave the classes
array in hiera file empty, thus resulting in a parsing error.
