### PR TITLE
WIP - Support step-by-step deployment running PuppetDB backend

### DIFF
--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -181,3 +181,19 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+
+anchors:
+  cloud::database::sql: mysql
+  cloud::messaging: rabbitmq
+  cloud::cache: memcached
+  cloud::storage::rbd::monitor: ceph-mon
+  cloud::identity: keystone
+  cloud::network::dhcp: neutron-dhcp-agent
+  cloud::loadbalancer: haproxy
+  cloud::storage::rbd::osd: ceph-osd
+  cloud::compute::hypervisor: nova-compute
+  cloud::compute::api: nova-api
+  cloud::dashboard: horizon
+  cloud::object::controller: swift-proxy
+  cloud::object::storage: swift-storage
+  cloud::spof: pacemaker

--- a/steps.yml.tmpl
+++ b/steps.yml.tmpl
@@ -1,0 +1,30 @@
+---
+{% for hname in hosts %}
+{% if profiles[hosts[hname]['profile']]['min_step'] %}
+{% if profiles[hosts[hname]['profile']]['min_step'] <= step %}
+{{ hname }}.{{ config.domain }}:
+{% if hosts[hname].ip %}
+  :server_ip: {{ hosts[hname].ip }}
+{% endif %}
+  :hostname: {{ hname }}
+  :roles:
+    - base
+{% for step_num in profiles[hosts[hname]['profile']]['steps'] %}
+{% if step_num <= step %}
+{% if profiles[hosts[hname]['profile']]['steps'][step_num]['roles'] %}
+{% for role in profiles[hosts[hname]['profile']]['steps'][step_num]['roles'] %}
+{% if serverspec[role] %}
+    - {{ serverspec[role] }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+
+{% endif %}
+{% endif %}
+{% endfor %}
+
+# Local variables:
+# mode: yaml
+# End:


### PR DESCRIPTION
Add a new backend (beside serverspec) to use PuppetDB for validating
that Puppet classes can be tested by integration tests withing Puppet
manifests.