### PR TITLE
Update neutron_dnsmasq_dns_servers parameter name

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -556,7 +556,7 @@ neutron_manage_haproxy_pkg: {{ config.neutron_manage_haproxy_pkg | default('fals
 neutron_plugin: {{ config.neutron_plugin | default('ml2') }}
 neutron_driver: {{ config.neutron_driver | default('ml2_ovs') }}
 neutron_veth_mtu: {{ config.neutron_veth_mtu | default('1500') }}
-neutron_dnsmasq_dns_server: {{ config.neutron_dnsmasq_dns_server | default('false') }}
+neutron_dnsmasq_dns_servers: {{ config.neutron_dnsmasq_dns_servers | default('false') }}
 
 neutron_metadata_enabled: {{ config.neutron_metadata_enabled | default('true') }}
 neutron_external_int: {{ config.neutron_external_int | default('"%{hiera(\'external_netif\')}"') }}

--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -402,7 +402,7 @@ cloud::network::lbaas::debug: "%{hiera('neutron_debug')}"
 
 cloud::network::dhcp::veth_mtu: "%{hiera('neutron_veth_mtu')}"
 cloud::network::dhcp::debug: "%{hiera('neutron_debug')}"
-cloud::network::dhcp::dnsmasq_dns_server: "%{hiera('neutron_dnsmasq_dns_server')}"
+cloud::network::dhcp::dnsmasq_dns_servers: "%{hiera('neutron_dnsmasq_dns_servers')}"
 cloud::network::dhcp::firewall_settings: "%{hiera('firewall_common_extras')}"
 
 cloud::network::controller::flat_networks: "%{hiera('neutron_flat_networks')}"


### PR DESCRIPTION
`neutron_dnsmasq_dns_server` parameter is deprecated, and replaced by `neutron_dnsmasq_dns_servers`
this parameter is now an array of DNS IP, with a default value to `false`.

Refs: https://github.com/enovance/puppet-openstack-cloud/pull/735
and https://github.com/openstack/neutron/commit/a269541c603f8923b35b7e722f1b8c0ebd42c95a
