### PR TITLE
Apply automatization of installserver on every infra

### DIFF
--- a/scenarios/2nodes/infra.yaml
+++ b/scenarios/2nodes/infra.yaml
@@ -10,6 +10,8 @@ profiles:
       1:
         roles:
           - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   controller:
     arity: 1
     edeploy: openstack-full
@@ -132,3 +134,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -3,6 +3,11 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+      1:
+        roles:
+          - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   controller:
     arity: 3+2n
     edeploy: openstack-full
@@ -126,3 +131,5 @@ serverspec:
   cloud::compute::api: controller
   cloud::dashboard: dashboard
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/3ctrl_xcpt/infra.yaml
+++ b/scenarios/3ctrl_xcpt/infra.yaml
@@ -7,6 +7,8 @@ profiles:
       1:
         roles:
           - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   controller:
     arity: 3
     edeploy: openstack-full
@@ -123,3 +125,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -10,6 +10,8 @@ profiles:
       1:
         roles:
           - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   openstack-full:
     arity: 3
     edeploy: openstack-full
@@ -105,3 +107,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -3,6 +3,11 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+      1:
+        roles:
+          - cloud
+          - cloud::install:puppetdb
+          - cloud::install:puppetmaster
   openstack-full:
     arity: 3
     edeploy: openstack-full
@@ -91,3 +96,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/ref-arch-packed/infra.yaml
+++ b/scenarios/ref-arch-packed/infra.yaml
@@ -7,6 +7,8 @@ profiles:
       1:
         roles:
           - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
     serverspec_config:
   controller:
     arity: 3+2n
@@ -133,3 +135,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -7,6 +7,8 @@ profiles:
       1:
         roles:
           - cloud
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   load-balancer:
     arity: 2+n
     edeploy: openstack-full
@@ -181,3 +183,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
+  cloud::install::puppetdb: puppetdb
+  cloud::install::puppetmaster: puppetmaster


### PR DESCRIPTION
A change has been made on puppet-openstack-cloud so that the
configuration install-server can be automated. This commit aims to add this
feature to the common set of infra we offer.
