### PR TITLE
Add missing steps: keyword

### DIFF
--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -3,6 +3,7 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+    steps:
       1:
         roles:
           - cloud

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -3,6 +3,7 @@ profiles:
   install-server:
     arity: 1
     edeploy: install-server
+    steps:
       1:
         roles:
           - cloud


### PR DESCRIPTION
the 'steps:' keyword is missing in two scenarios causing the install-flow to fail.
This commit fixes that.
