### PR TITLE
scenarios/3nodes_cephless: fixed typo on classes names

### DIFF
--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -7,8 +7,8 @@ profiles:
       1:
         roles:
           - cloud
-          - cloud::install:puppetdb
-          - cloud::install:puppetmaster
+          - cloud::install::puppetdb
+          - cloud::install::puppetmaster
   openstack-full:
     arity: 3
     edeploy: openstack-full


### PR DESCRIPTION
small typo on class names for step 1 of install-server
