### PR TITLE
glance_api_policies: Set default values in common

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -311,6 +311,17 @@ glance_api_use_syslog: {{ config.glance_api_use_syslog | default('"%{hiera(\'use
 glance_api_log_facility: {{ config.glance_api_log_facility | default('"%{hiera(\'log_facility\')}"') }}
 {% if config.glance_api_policies %}
 glance_api_policies: {{ config.glance_api_policies }}
+{% else %}
+glance_api_policies:
+  delete_image_location:
+    key: delete_image_location
+    value: 'role:admin'
+  get_image_location:
+    key: get_image_location
+    value: 'role:admin'
+  set_image_location:
+    key: set_image_location
+    value: 'role:admin'
 {% endif %}
 
 glance_registry_verbose: {{ config.glance_registry_verbose | default('"%{hiera(\'verbose\')}"') }}

--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -262,9 +262,7 @@ cloud::image::api::nfs_device: "%{hiera('glance_nfs_device')}"
 cloud::image::api::nfs_options: "%{hiera('glance_nfs_options')}"
 cloud::image::api::pipeline: "%{hiera('glance_api_pipeline')}"
 cloud::image::api::firewall_settings: "%{hiera('firewall_common_extras')}"
-{% if config.glance_api_policies %}
 cloud::image::api::api_policies: "%{hiera('glance_api_policies')}"
-{% endif %}
 
 cloud::image::registry::glance_db_host: "%{hiera('glance_db_host')}"
 cloud::image::registry::glance_db_user: "%{hiera('glance_db_user')}"


### PR DESCRIPTION
To follow current pattern the parameters default are set in the
common.yaml.tmpl file.

If the user does not specify any glance_api_policies, spinalstack
will protect the user from OSSA-2014-041.
