### PR TITLE
Configure PuppetDB on each node

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -820,78 +820,6 @@ kibana_config_es_server: {{ config.kibana_config_es_server | default('"%{::ipadd
 kibana_config_index: {{ config.kibana_config_index | default('fluentd') }}
 fluentd_version: {{ config.fluentd_version | default('2') }}
 
-# PuppetMaster
-autosign_domains: {{ config.autosign_domains | default(['*']) }}
-puppetdb_enable: {{ config.puppetdb_enable | default('true') }}
-puppetmaster_puppetconf_path: {{ config.puppetmaster_puppetconf_path | default('/etc/puppet/puppet.conf') }}
-{% if config.puppetmaster_package_name %}
-puppetmaster_package_name: {{ config.puppetmaster_package_name }}
-{% endif %}
-{% if config.puppetmaster_service_name %}
-puppetmaster_service_name: {{ config.puppetmaster_service_name }}
-{% endif %}
-{% if config.puppetmaster_main_configuration %}
-puppetmaster_main_configuration :
-{% for check, desc in config.puppetmaster_main_configuration.iteritems() %}
-  {{ check }}:
-  {% for key, value in desc.iteritems() %}
-    {{ key }}: {{ value }}
-  {% endfor %}
-{% endfor %}
-{% else %}
-puppetmaster_main_configuration: {}
-{% endif %}
-{% if config.puppetmaster_agent_configuration %}
-puppetmaster_agent_configuration :
-{% for check, desc in config.puppetmaster_agent_configuration.iteritems() %}
-  {{ check }}:
-  {% for key, value in desc.iteritems() %}
-    {{ key }}: {{ value }}
-  {% endfor %}
-{% endfor %}
-{% else %}
-puppetmaster_agent_configuration: {}
-{% endif %}
-{% if config.puppetmaster_master_configuration %}
-puppetmaster_master_configuration :
-{% for check, desc in config.puppetmaster_master_configuration.iteritems() %}
-  {{ check }}:
-  {% for key, value in desc.iteritems() %}
-    {{ key }}: {{ value }}
-  {% endfor %}
-{% endfor %}
-{% else %}
-puppetmaster_master_configuration: {}
-{% endif %}
-{% if config.puppetmaster_master_configuration %}
-puppetmaster_master_configuration :
-{% for check, desc in config.puppetmaster_master_configuration.iteritems() %}
-  {{ check }}:
-  {% for key, value in desc.iteritems() %}
-    {{ key }}: {{ value }}
-  {% endfor %}
-{% endfor %}
-{% else %}
-puppetmaster_master_configuration: {}
-{% endif %}
-{% if config.puppetmaster_vhost_configuration %}
-puppetmaster_vhost_configuration :
-{% for check, desc in config.puppetmaster_vhost_configuration.iteritems() %}
-  {{ check }}:
-  {% for key, value in desc.iteritems() %}
-    {{ key }}: {{ value }}
-  {% endfor %}
-{% endfor %}
-{% else %}
-puppetmaster_vhost_configuration: {}
-{% endif %}
-{% if config.passenger_root %}
-apache::mod::passenger::passenger_root: {{ config.passenger_root }}
-{% endif %}
-{% if config.passenger_mod_lib_path %}
-apache::mod::passenger::mod_lib_path: {{ config.passenger_mod_lib_path }}
-{% endif %}
-
 # Rsyslog
 rsyslog::client::log_remote: {{ config.syslog_log_remote | default('true') }}
 rsyslog::client::log_local: {{ config.syslog_log_local | default('true') }}
@@ -900,10 +828,31 @@ rsyslog::client::remote_forward_format: RSYSLOG_TraditionalForwardFormat
 rsyslog::client::port: {{ config.syslog_port }}
 rsyslog::client::server: {{ config.syslog_server }}
 
+# PuppetDB
+puppetdb::disable_ssl: true
+{% if config.puppetdb_server %}
+puppetdb::master::config::puppetdb_server: {{ config.puppetdb_server }}
+{% else %}
+{% for hname in hosts %}
+{% if hosts[hname].profile == 'install-server' %}
+puppetdb::master::config::puppetdb_server: {{ hname }}
+{% endif %}
+{% endfor %}
+{% endif %}
+puppetdb::master::config::manage_report_processor: true
+puppetdb::master::config::restart_puppet: false
+puppetdb::master::config::enable_reports: true
+puppetdb::master::config::strict_validation: false
+puppetdb::master::config::puppet_conf_section: main
+puppetdb::master::config::puppetdb_port: 8081
+puppetdb::master::routes::routes:
+  apply:
+    catalog:
+      terminus: compiler
+      cache: puppetdb
+    facts:
+      terminus: facter
+      cache: puppetdb_apply
+
 # HAproxy
 haproxy_auth: {{ config.haproxy_auth | default('admin:changeme') }}
-
-# This is needed for initial bootstrap
-# before step1 is even generated
-classes:
- - cloud

--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -3,6 +3,8 @@
 {% if prof == profile %}
 {% if profiles[profile]['steps'] %}
 classes:
+  - cloud
+  - cloud::install::puppetdb::config
 {% for step_num in profiles[profile]['steps'] %}
 {% if step_num <= step %}
 {% for role in profiles[profile]['steps'][step_num]['roles'] %}
@@ -289,63 +291,6 @@ cloud::image::registry::debug: "%{hiera('glance_registry_debug')}"
 cloud::image::registry::log_facility: "%{hiera('glance_registry_log_facility')}"
 cloud::image::registry::use_syslog: "%{hiera('glance_registry_use_syslog')}"
 cloud::image::registry::firewall_settings: "%{hiera('firewall_common_extras')}"
-
-#
-# cloud::install
-#
-#cloud::install::puppetmaster::puppetmaster_package_name: "%{hiera('puppetmaster_package_name')}"
-#cloud::install::puppetmaster::puppetmaster_service_name: "%{hiera('puppetmaster_service_name')}"
-cloud::install::puppetmaster::main_configuration: "%{hiera('puppetmaster_main_configuration')}"
-cloud::install::puppetmaster::agent_configuration: "%{hiera('puppetmaster_agent_configuration')}"
-cloud::install::puppetmaster::master_configuration: "%{hiera('puppetmaster_master_configuration')}"
-cloud::install::puppetmaster::puppetmaster_vhost_configuration: "%{hiera('puppetmaster_vhost_configuration')}"
-cloud::install::puppetmaster::puppetconf_path: "%{hiera('puppetmaster_puppetconf_path')}"
-cloud::install::puppetmaster::puppetdb_enable: "%{hiera('puppetdb_enable')}"
-cloud::install::puppetmaster::autosign_domains: "%{hiera('autosign_domains')}"
-cloud::install::puppetmaster::autosign_domains:
-  - '*'
-cloud::install::puppetmaster::master_configuration:
-  ssl_client_header:
-    setting: ssl_client_header
-    value: SSL_CLIENT_S_DN
-  ssl_client_verify_header:
-    setting: ssl_client_verify_header
-    value: SSL_CLIENT_VERIFY
-cloud::install::puppetmaster::agent_configuration:
-  certname:
-    setting: certname
-    value: "%{::fqdn}"
-  server:
-    setting: server
-    value: "%{::fqdn}"
-cloud::install::puppetmaster::puppetmaster_vhost_configuration:
-  puppetmasterd:
-   docroot: '/usr/share/puppet/rack/puppetmasterd/public'
-   port: 8140
-   ssl: true
-   ssl_protocol: 'ALL -SSLv2 -SSLv3'
-   ssl_cipher: 'ALL:!aNULL:!eNULL:!DES:!3DES:!IDEA:!SEED:!DSS:!PSK:!RC4:!MD5:+HIGH:+MEDIUM:!LOW:!SSLv2:!EXP'
-   ssl_honorcipherorder: 'On'
-   ssl_cert: "/var/lib/puppet/ssl/certs/%{::fqdn}.pem"
-   ssl_key: "/var/lib/puppet/ssl/private_keys/%{::fqdn}.pem"
-   ssl_chain: "/var/lib/puppet/ssl/certs/ca.pem"
-   ssl_ca: "/var/lib/puppet/ssl/certs/ca.pem"
-   ssl_verify_client: optional
-   ssl_verify_depth: 1
-   ssl_options:
-     - +StdEnvVars
-     - +ExportCertData
-   request_headers:
-     - 'unset X-Forwarded-For'
-     - "set X-SSL-Subject %%{}{SSL_CLIENT_S_DN}e"
-     - "set X-Client-DN %%{}{SSL_CLIENT_S_DN}e"
-     - "set X-Client-Verify %%{}{SSL_CLIENT_VERIFY}e"
-   rack_base_uris: '/'
-   add_default_charset: 'UTF-8'
-puppetdb::master::config::puppetdb_server: "%{::fqdn}"
-puppetdb::master::config::manage_report_processor: true
-puppetdb::master::config::enable_reports: true
-puppetdb::master::config::strict_validation: false
 
 #
 # cloud::loadbalancer

--- a/scenarios/2nodes/infra.yaml
+++ b/scenarios/2nodes/infra.yaml
@@ -9,17 +9,16 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis::server
+          - cloud::install::puppetdb::server
+    serverspec_config:
+      puppetdb_server: puppetdb_server
   controller:
     arity: 1
     edeploy: openstack-full
     steps:
       1:
         roles:
-          - cloud
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb
           - cloud::messaging
@@ -88,13 +87,11 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   compute:
     arity: 1
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       4:
         roles:
           - cloud::compute::hypervisor
@@ -114,6 +111,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -136,5 +134,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -6,10 +6,10 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis
+          - cloud::install::puppetdb::server
+    serverspec_config:
+      puppetdb_server: puppetdb_server
   controller:
     arity: 3+2n
     edeploy: openstack-full
@@ -66,11 +66,12 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   networker:
     arity: 3+2n
     edeploy: openstack-full
     steps:
-       5:
+      5:
         roles:
           - cloud::network::dhcp
           - cloud::network::metadata
@@ -92,6 +93,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   compute:
     arity: 1+n
     edeploy: openstack-full
@@ -115,6 +117,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -133,5 +136,5 @@ serverspec:
   cloud::compute::api: controller
   cloud::dashboard: dashboard
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/3ctrl_xcpt/infra.yaml
+++ b/scenarios/3ctrl_xcpt/infra.yaml
@@ -6,17 +6,16 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis::server
+          - cloud::install::puppetdb::server
+    serverspec_config:
+      puppetdb_server: puppetdb_server
   controller:
     arity: 3
     edeploy: openstack-full
     steps:
       1:
         roles:
-          - cloud
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb
           - cloud::messaging
@@ -80,13 +79,11 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   compute:
     arity: 1+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       4:
         roles:
           - cloud::compute::hypervisor
@@ -106,6 +103,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 ordered_profiles:
   - install-server
   - controller
@@ -127,5 +125,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -9,17 +9,16 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis::server
+          - cloud::install::puppetdb::server
+    serverspec_config:
+      puppetdb_server: puppetdb_server
   openstack-full:
     arity: 3
     edeploy: openstack-full
     steps:
       1:
         roles:
-          - cloud
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb
           - cloud::messaging
@@ -88,6 +87,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -109,5 +109,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -6,10 +6,10 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis::server
+          - cloud::install::puppetdb::server
+    serverspec_config:
+      puppetdb_server: puppetdb_server
   openstack-full:
     arity: 3
     edeploy: openstack-full
@@ -80,6 +80,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -99,5 +100,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/ref-arch-packed/infra.yaml
+++ b/scenarios/ref-arch-packed/infra.yaml
@@ -6,18 +6,16 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
           - cloud::database::nosql::redis
+          - cloud::install::puppetdb::server
     serverspec_config:
+      puppetdb_server: puppetdb_server
   controller:
     arity: 3+2n
     edeploy: openstack-full
     steps:
       1:
         roles:
-          - cloud
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb
           - cloud::messaging
@@ -81,14 +79,12 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
         --------------------------------
   storage-compute:
     arity: 3+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       2:
         roles:
           - cloud::storage::rbd::osd
@@ -115,6 +111,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -137,5 +134,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::server: puppetdb_config

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -6,17 +6,12 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
-          - cloud::install::puppetdb
-          - cloud::install::puppetmaster
+          - cloud::install::puppetdb::server
           - cloud::database::nosql::redis::server
   load-balancer:
     arity: 2+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       2:
         roles:
           - cloud::loadbalancer
@@ -42,7 +37,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb
           - cloud::messaging
@@ -105,13 +99,11 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   compute:
     arity: 1+n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       4:
         roles:
           - cloud::compute::hypervisor
@@ -131,13 +123,11 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
   storage:
     arity: 3+2n
     edeploy: openstack-full
     steps:
-      1:
-        roles:
-          - cloud
       2:
         roles:
           - cloud::storage::rbd::osd
@@ -161,6 +151,7 @@ profiles:
       neutron_firewall_driver: neutron_firewall_driver
       syslog_server: syslog_server
       syslog_port: syslog_port
+      puppetdb_server: puppetdb_server
 
 ordered_profiles:
   - install-server
@@ -185,5 +176,5 @@ serverspec:
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::spof: spof
-  cloud::install::puppetdb: puppetdb
-  cloud::install::puppetmaster: puppetmaster
+  cloud::install::puppetdb::server: puppetdb_server
+  cloud::install::puppetdb::config: puppetdb_config


### PR DESCRIPTION
In order for puppet-openstack-cloud to be installed in a masterless way
every node needs to have their puppetdb conf properly set. This is what
this commit allow.