### PR TITLE
Add lookup for logging::server parameters

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -812,14 +812,21 @@ logging_logrotate_rule:
 {% else %}
 logging_logrotate_rule: {}
 {% endif %}
-kibana_servername: {{ config.kibana_servername | default('"%{::fqdn}"') }}
-kibana_port: {{ config.kibana_port | default('8300') }}
-kibana_manage_git_repository: {{ config.kibana_manage_git_repository | default('false') }}
-kibana_manage_ws: {{ config.kibana_manage_ws | default('true') }}
-kibana_config_es_server: {{ config.kibana_config_es_server | default('"%{::ipaddress}"') }}
-kibana_config_index: {{ config.kibana_config_index | default('fluentd') }}
-fluentd_version: {{ config.fluentd_version | default('2') }}
-
+fluentd::version: {{ config.fluentd_version | default('2') }}
+kibana3::ws_extras:
+  ip: {{ config.kibana_bind_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
+kibana3::ws_servername: {{ config.kibana_servername | default('"%{hiera(\'vip_public_fqdn\')}"') }}
+kibana3::ws_port: {{ config.kibana_port | default('\'8300\'') }}
+kibana3::manage_git_repository: {{ config.kibana_manage_git_repository | default('false') }}
+kibana3::manage_ws: {{ config.kibana_manage_ws | default('true') }}
+kibana3::config_es_server: {{ config.kibana_es_server | default('"%{hiera(\'vip_internal_ip\')}"') }}
+kibana3::config_kibana_index: {{ config.kibana_es_index | default('fluentd') }}
+kibana_bind_ip: {{ config.kibana_bind_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
+elasticsearch_port: 9200
+elasticsearch_bind_ip: {{ config.elasticsearch_bind_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
+elasticsearch::config:
+  'cluster.name': fluentd
+  'network.host': {{ config.elasticsearch_bind_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
 # Rsyslog
 rsyslog::client::log_remote: {{ config.syslog_log_remote | default('true') }}
 rsyslog::client::log_local: {{ config.syslog_log_local | default('true') }}
@@ -856,3 +863,6 @@ puppetdb::master::routes::routes:
 
 # HAproxy
 haproxy_auth: {{ config.haproxy_auth | default('admin:changeme') }}
+
+# Apache Httpd
+apache::default_vhost: false

--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -48,11 +48,21 @@ cloud::firewall::post::debug: "%{hiera('firewall_debug')}"
 #
 cloud::database::nosql::memcached::listen_ip: "%{hiera('internal_netif_ip')}"
 cloud::database::nosql::memcached::firewall_settings: "%{hiera('firewall_common_extras')}"
+
+#
+# cloud::database::nosql::redis
+#
 cloud::database::nosql::redis::server::port: "%{hiera('redis_port')}"
 cloud::database::nosql::redis::server::firewall_settings: "%{hiera('firewall_common_extras')}"
 cloud::database::nosql::redis::sentinel::port: "%{hiera('sentinel_port')}"
 cloud::database::nosql::redis::sentinel::firewall_settings: "%{hiera('firewall_common_extras')}"
 
+#
+# cloud::database::nosql::elasticsearch
+#
+cloud::database::nosql::elasticsearch::listen_port: "%{hiera('elsaticsearch_port')}"
+cloud::database::nosql::elasticsearch::listen_ip: "%{hiera('elasticsearch_bind_ip')}"
+cloud::database::nosql::elasticsearch::firewall_settings: "%{hiera('firewall_common_extras')}"
 #
 # cloud::compute
 #
@@ -722,18 +732,13 @@ cloud::storage::rbd::pools::ceph_fsid: "%{hiera('ceph_fsid')}"
 #
 # cloud::logging
 #
+cloud::logging::server::kibana_port: "%{hiera('kibana3::ws_port')}"
+cloud::logging::server::kibana_bind_ip: "%{hiera('kibana_bind_ip')}"
 cloud::logging::agent::syslog_enable: "%{hiera('logging_syslog_enable')}"
 cloud::logging::agent::sources: "%{hiera('logging_sources')}"
 cloud::logging::agent::matches: "%{hiera('logging_matches')}"
 cloud::logging::agent::plugins: "%{hiera('logging_plugins')}"
 cloud::logging::agent::logrotate_rule: "%{hiera('logging_logrotate_rule')}"
-fluentd::version: "%{hiera('fluentd_version')}"
-kibana3::ws_servername: "%{hiera('kibana_servername')}"
-kibana3::ws_port: "%{hiera('kibana_port')}"
-kibana3::manage_git_repository: "%{hiera('kibana_manage_git_repository')}"
-kibana3::manage_ws: "%{hiera('kibana_manage_ws')}"
-kibana3::config_es_server: "%{hiera('kibana_config_es_server')}"
-kibana3::config_kibana_index: "%{hiera('kibana_config_index')}"
 
 #
 # cloud::monitoring


### PR DESCRIPTION
Add lookups for new logging::server parameters needed by the
haproxy member resource to allow HA in logging infrastructure.