### PR TITLE
Update the arity of storage from 3+2n to 3+1n for ref-arch

### DIFF
--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -125,7 +125,7 @@ profiles:
       syslog_port: syslog_port
       puppetdb_server: puppetdb_server
   storage:
-    arity: 3+2n
+    arity: 3+1n
     edeploy: openstack-full
     steps:
       2:


### PR DESCRIPTION
I don't really understand why the arity is set to 3+2n. I understand
that 3 is now the standard factor of replication but I don't understand
why it's not possible to have let say 6 storage nodes :)