### PR TITLE
infra: Enable Redis sentinel on controller nodes

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -195,9 +195,24 @@ mongodb::server::replset: {{ config.mongodb_replset | default('ceilometer') }}
 mongodb::server::logpath: {{ config.mongodb_logpath | default('/var/log/mongodb/mongod.log') }}
 
 # Redis
+redis: {{ config.redis | default('true') }}
+redis_bind_ip: {{ config.redis_bind_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
 redis_port: {{ config.redis_port | default('6379') }}
-sentinel_port: {{ config.sentinel_port | default('26379') }}
+redis_bind_options: {{ config.redis_bind_options | default('"%{hiera(\'haproxy_default_bind_options\')}"') }}
+redis_haproxy_port: {{ config.redis_haproxy_port | default('"%{hiera(\'redis_port\')}"') }}
 
+sentinel_port: {{ config.sentinel_port | default('26379') }}
+sentinel_haproxy_monitor_ip: {{ config.sentinel_haproxy_monitor_ip | default('"%{hiera(\'vip_public_ip\')}"') }}
+sentinel_haproxy_monitor_port: {{ config.sentinel_haproxy_monitor_port | default('10300') }}
+
+redis::bind: {{ config.redis_port | default('"%{hiera(\'redis_bind_ip\')}"') }}
+redis::port: {{ config.redis_port | default('"%{hiera(\'redis_port\')}"') }}
+
+redis::sentinel::down_after: {{ config.sentinel_down_ater | default('1000') }}
+redis::sentinel::failover_timeout: {{ config.sentinel_failover_timeout | default('1000') }}
+redis::sentinel::master_name: {{ config.redis_master_name }}
+redis::sentinel::redis_host: {{ config.redis_master_ip | default('"%{hiera(\'redis::sentinel::master_name\')}"')}}
+redis::sentinel::notification_script: {{ config.sentinel_notification_script | default('/bin/redis-notifications.sh') }}
 
 # MySQL
 galera_ip: {{ config.galera_ip | default('"%{hiera(\'vip_internal_ip\')}"') }}
@@ -812,7 +827,7 @@ sensu_dashboard_bind_options: {{ config.sensu_dashboard_bind_options | default('
 sensu_api_bind_options: {{ config.sensu_api_bind_options | default('"%{hiera(\'haproxy_default_bind_options\')}"') }}
 
 sensu_dashboard_port: {{ config.sensu_dashboard_port | default('3000') }}
-sensu_api_port: {{ config.sensu_api_port | default('4567') }}
+sensu_api_port: {{ config.sensu_api_port | default('4568') }}
 sensu_api_ip: {{ config.sensu_api_ip | default('"%{hiera(\'internal_netif_ip\')}"') }}
 
 sensu_manage_rabbitmq_resources: {{ config.sensu_manage_rabbitmq_resources | default('false') }}
@@ -824,6 +839,20 @@ sensu_uchiwa_ip: {{ config.sensu_uchiwa_ip | default('"%{hiera(\'internal_netif_
 sensu_uchiwa_user: {{ config.sensu_uchiwa_user | default('admin') }}
 sensu_uchiwa_password: {{ config.sensu_uchiwa_password | default('password') }}
 sensu_uchiwa_install_repo: {{ config.sensu_uchiwa_install_repo | default('false') }}
+sensu::api_bind: "%{hiera('sensu_api_ip')}"
+sensu::api_port: "%{hiera('sensu_api_port')}"
+sensu::redis_host: {{ config.sensu_redis_host | default('"%{hiera(\'vip_public_ip\')}"') }}
+sensu::redis_port: {{ config.sensu_redis_port | default('"%{hiera(\'redis_port\')}"') }}
+sensu::rabbitmq_password: "%{hiera('sensu_rabbitmq_password')}"
+sensu::rabbitmq_host: "%{hiera('rabbit_host')}"
+sensu::rabbitmq_vhost: "%{hiera('sensu_rabbitmq_vhost')}"
+sensu::install_repo: "%{hiera('sensu_install_repo')}"
+uchiwa::install_repo: "%{hiera('sensu_uchiwa_install_repo')}"
+uchiwa::user: "%{hiera('sensu_uchiwa_user')}"
+uchiwa::pass: "%{hiera('sensu_uchiwa_password')}"
+uchiwa::host: "%{hiera('sensu_uchiwa_ip')}"
+uchiwa::port: "%{hiera('sensu_dashboard_port')}"
+
 
 # Logging
 logging_syslog_enable: {{ config.logging_syslog_enable | default('true') }}

--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -54,9 +54,12 @@ cloud::database::nosql::memcached::firewall_settings: "%{hiera('firewall_common_
 #
 # cloud::database::nosql::redis
 #
+cloud::database::nosql::redis::server::bind_ip: "%{hiera('redis_bind_ip')}"
 cloud::database::nosql::redis::server::port: "%{hiera('redis_port')}"
 cloud::database::nosql::redis::server::firewall_settings: "%{hiera('firewall_common_extras')}"
 cloud::database::nosql::redis::sentinel::port: "%{hiera('sentinel_port')}"
+cloud::database::nosql::redis::sentinel::haproxy_monitor_ip: "%{hiera('sentinel_haproxy_monitor_ip')}"
+cloud::database::nosql::redis::sentinel::haproxy_monitor_port: "%{hiera('sentinel_haproxy_monitor_port')}"
 cloud::database::nosql::redis::sentinel::firewall_settings: "%{hiera('firewall_common_extras')}"
 
 #
@@ -330,6 +333,7 @@ cloud::loadbalancer::horizon_ssl: "%{hiera('horizon_ssl')}"
 cloud::loadbalancer::spice: "%{hiera('spice')}"
 cloud::loadbalancer::rabbitmq: "%{hiera('rabbit')}"
 cloud::loadbalancer::kibana: "%{hiera('kibana3')}"
+cloud::loadbalancer::redis: "%{hiera('redis')}"
 cloud::loadbalancer::elasticsearch: "%{hiera('elasticsearch')}"
 cloud::loadbalancer::sensu_dashboard: "%{hiera('sensu_dashboard')}"
 cloud::loadbalancer::sensu_api: "%{hiera('sensu_api')}"
@@ -363,6 +367,7 @@ cloud::loadbalancer::spice_bind_options: "%{hiera('spice_bind_options')}"
 cloud::loadbalancer::kibana_bind_options: "%{hiera('kibana3_bind_options')}"
 cloud::loadbalancer::sensu_dashboard_bind_options: "%{hiera('sensu_dashboard_bin_options')}"
 cloud::loadbalancer::sensu_api_bind_options: "%{hiera('sensu_api_bind_options')}"
+cloud::loadbalancer::redis_bind_options: "%{hiera('redis_bind_options')}"
 cloud::loadbalancer::elasticsearch_bind_options: "%{hiera('elasticsearch_bind_options')}"
 cloud::loadbalancer::horizon_bind_options: "%{hiera('horizon_bind_options')}"
 cloud::loadbalancer::horizon_ssl_bind_options: "%{hiera('horizon_ssl_bind_options')}"
@@ -387,6 +392,7 @@ cloud::loadbalancer::horizon_port: "%{hiera('horizon_port')}"
 cloud::loadbalancer::horizon_ssl_port: "%{hiera('horizon_ssl_port')}"
 cloud::loadbalancer::spice_port: "%{hiera('spice_port')}"
 cloud::loadbalancer::kibana_port: "%{hiera('kibana3_port')}"
+cloud::loadbalancer::redis_port: "%{hiera('redis_haproxy_port')}"
 cloud::loadbalancer::elasticsearch_port: "%{hiera('elasticsearch_port')}"
 cloud::loadbalancer::sensu_dashboard_port: "%{hiera('sensu_dashboard_port')}"
 cloud::loadbalancer::sensu_api_port: "%{hiera('sensu_api_port')}"
@@ -786,20 +792,11 @@ cloud::monitoring::server::sensu::rabbitmq_user: "%{hiera('sensu_rabbitmq_user')
 cloud::monitoring::server::sensu::rabbitmq_password: "%{hiera('sensu_rabbitmq_password')}"
 cloud::monitoring::server::sensu::rabbitmq_vhost: "%{hiera('sensu_rabbitmq_vhost')}"
 cloud::monitoring::server::sensu::uchiwa_ip: "%{hiera('sensu_uchiwa_ip')}"
+cloud::monitoring::server::sensu::uchiwa_port:  "%{hiera('sensu_dashboard_port')}"
 cloud::monitoring::server::sensu::manage_rabbitmq_resources: "%{hiera('sensu_manage_rabbitmq_resources')}"
 cloud::monitoring::server::sensu::sensu_api_ip: "%{hiera('sensu_api_ip')}"
 cloud::monitoring::server::sensu::sensu_api_port: "%{hiera('sensu_api_port')}"
-cloud::monitoring::server::sensu::uchiwa_port:  "%{hiera('sensu_dashboard_port')}"
 cloud::monitoring::server::sensu::firewall_settings: "%{hiera('firewall_common_extras')}"
-
-
-uchiwa::install_repo: "%{hiera('sensu_uchiwa_install_repo')}"
-uchiwa::user: "%{hiera('sensu_uchiwa_user')}"
-uchiwa::pass: "%{hiera('sensu_uchiwa_password')}"
-sensu::rabbitmq_password: "%{hiera('sensu_rabbitmq_password')}"
-sensu::rabbitmq_host: "%{hiera('rabbit_host')}"
-sensu::rabbitmq_vhost: "%{hiera('sensu_rabbitmq_vhost')}"
-sensu::install_repo: "%{hiera('sensu_install_repo')}"
 
 # Experimental
 # cloud::database::dbaas::trove_db_host: "%{hiera('trove_db_host')}"

--- a/scenarios/2nodes/infra.yaml
+++ b/scenarios/2nodes/infra.yaml
@@ -9,7 +9,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis::server
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -21,6 +20,7 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
           - cloud::messaging
           - cloud::database::nosql::memcached
           - cloud::storage::rbd::monitor

--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -6,7 +6,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -18,6 +17,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
       2:
@@ -128,6 +129,8 @@ serverspec:
   cloud::database::sql::mysql: database
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
+  cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_sentinel
   cloud::identity: identity
   cloud::network::dhcp: network
   cloud::loadbalancer: lb

--- a/scenarios/3ctrl_xcpt/infra.yaml
+++ b/scenarios/3ctrl_xcpt/infra.yaml
@@ -6,7 +6,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis::server
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -18,6 +17,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
           - cloud::storage::rbd::monitor
@@ -113,6 +114,7 @@ serverspec:
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
   cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_sentinel
   cloud::storage::rbd::monitor: storage_controller
   cloud::identity: identity
   cloud::network::dhcp: network

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -9,7 +9,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis::server
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -21,6 +20,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
           - cloud::storage::rbd::monitor
@@ -93,6 +94,7 @@ serverspec:
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
   cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_sentinel
   cloud::storage::rbd::monitor: storage_controller
   cloud::identity: identity
   cloud::network::dhcp: network

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -6,7 +6,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis::server
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -18,6 +17,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
       2:
@@ -86,6 +87,7 @@ serverspec:
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
   cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_sentinel
   cloud::identity: identity
   cloud::network::dhcp: network
   cloud::loadbalancer: lb

--- a/scenarios/ref-arch-packed/infra.yaml
+++ b/scenarios/ref-arch-packed/infra.yaml
@@ -6,7 +6,6 @@ profiles:
     steps:
       1:
         roles:
-          - cloud::database::nosql::redis
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
@@ -18,6 +17,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
           - cloud::storage::rbd::monitor
@@ -119,6 +120,7 @@ serverspec:
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
   cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_server
   cloud::storage::rbd::monitor: storage_controller
   cloud::identity: identity
   cloud::network::dhcp: network

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -7,7 +7,6 @@ profiles:
       1:
         roles:
           - cloud::install::puppetdb::server
-          - cloud::database::nosql::redis::server
   load-balancer:
     arity: 2+n
     edeploy: openstack-full
@@ -39,6 +38,8 @@ profiles:
         roles:
           - cloud::database::sql::mysql
           - cloud::database::nosql::mongodb::mongod
+          - cloud::database::nosql::redis::server
+          - cloud::database::nosql::redis::sentinel
           - cloud::messaging
           - cloud::database::nosql::memcached
           - cloud::storage::rbd::monitor
@@ -159,6 +160,7 @@ serverspec:
   cloud::messaging: messaging
   cloud::database::nosql::memcached: cache
   cloud::database::nosql::redis::server: redis_server
+  cloud::database::nosql::redis::sentinel: redis_sentinel
   cloud::storage::rbd::monitor: storage_controller
   cloud::identity: identity
   cloud::network::dhcp: network


### PR DESCRIPTION
This commit aims to instantiate Redis sentinel on each controller
node. This  way the Redis can work as a cluster and provide failover.