### PR TITLE
common: Allow binding of mysqlchk

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -224,7 +224,7 @@ galera_master_name: {{ config.galera_master_name }}
 galera_internal_ips: {{ config.galera_internal_ips | default('"%{hiera(\'mgmt_internal_ips\')}"') }}
 mysql_root_password: {{ config.mysql_root_password }}
 mysql_sys_maint_password: {{ config.mysql_sys_maint_password | default('sys_maint') }}
-galera_clustercheck_ipaddress: "%{hiera('internal_netif_ip')}"
+galera_clustercheck_ipaddress: {{ config.galera_clustercheck_ipaddress | default('"%{hiera(\'internal_netif_ip\')}"') }}
 galera_clustercheck_dbuser: {{ config.galera_clustercheck_dbuser | default ('clustercheck') }}
 galera_clustercheck_dbpassword: {{ config.galera_clustercheck_dbpassword | default ('clustercheckpassword') }}
 galera_gcache: {{ config.galera_gcache | default('1G') }}


### PR DESCRIPTION
If galera is not bind on internal network then the mysqlchk service still bind
on it because we can't override the value of galera_clustercheck_ipaddress in
the env yaml file.
The haproxy galera backend expects to have port 3306 and 8200 on the same
network.