### PR TITLE
Moving the pool setup on controller

### DIFF
--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -44,6 +44,7 @@ profiles:
       3:
         roles:
           - cloud::identity
+          - cloud::storage::rbd::pools
       4:
         roles:
           - cloud::compute::api
@@ -125,9 +126,6 @@ profiles:
         roles:
           - cloud::storage::rbd::osd
           - cloud::object::storage
-      3:
-        roles:
-          - cloud::storage::rbd::pools
     serverspec_config:
       ks_user_name: ks_admin_tenant
       ks_user_password: ks_admin_password


### PR DESCRIPTION
The pool setup should be executed on controller and not on the storage nodes.