### PR TITLE
Specify path to MongoDB configuration

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -197,6 +197,7 @@ mongodb::server::bind_ip: {{ config.mongod_bindip | default('"%{hiera(\'internal
 mongodb::server::nojournal: {{ config.mongo_nojournal | default('false') }}
 mongodb::server::replset: {{ config.mongodb_replset | default('ceilometer') }}
 mongodb::server::logpath: {{ config.mongodb_logpath | default('/var/log/mongodb/mongod.log') }}
+mongodb::server::config: '/etc/mongod.conf'
 
 # Redis
 redis: {{ config.redis | default('true') }}


### PR DESCRIPTION
In J-1.1.0, we used to install a version of the MongoDB package that was
reading its configuration from /etc/mongodb.conf, with the newer version
of the package the conf is read from /etc/mongod.conf