### PR TITLE
data/type.yaml: Make it possible to set per-profile/type extra hiera config

### DIFF
--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -1,6 +1,11 @@
 # {{ profile }}
 {% for prof in profiles %}
 {% if prof == profile %}
+{% if profiles[prof].config %}
+{% for conf in profiles[prof].config %}
+{{ conf }}: {% if profiles[prof].config[conf] is string %}"{% endif %}{{ profiles[prof].config[conf] }}{% if profiles[prof].config[conf] is string %}"{% endif %}
+{% endfor %}
+{% endif %}
 {% if profiles[profile]['steps'] %}
 classes:
   - cloud


### PR DESCRIPTION
The idea is to enable something like the following:

    infra: ref-arch
    profiles:
    ...
      compute:
        config:
          nova::scheduler::filter::ram_allocation_ratio: 4
          nova::scheduler::filter::cpu_allocation_ratio: 16
    ...

    hosts:
    ....