### PR TITLE
fix typo in 3ctrl_xcpt_splitted-storage scenario

### DIFF
--- a/scenarios/3ctrl_xcpt_splitted-storage/infra.yaml
+++ b/scenarios/3ctrl_xcpt_splitted-storage/infra.yaml
@@ -1,4 +1,4 @@
-name: 3ctrl-xcpt-splitted-storage
+name: 3ctrl_xcpt_splitted-storage
 profiles:
   install-server:
     arity: 1
@@ -17,8 +17,8 @@ profiles:
           - cloud::storage::rbd::key
       2:
         roles:
-          - cloud::dashboard
           - cloud::loadbalancer
+          - cloud::dashboard
       3:
         roles:
           - cloud::identity


### PR DESCRIPTION
Fix typo in infra name.

```
Incoherent infra(3ctrl-xcpt-splitted-storage) and env(3ctrl_xcpt_splitted-storage)
```