### PR TITLE
fix typo in 3ctrl_xcpt_splitted-storage scenario (like #52)

### DIFF
--- a/scenarios/3ctrl_xcpt_splitted-storage/infra.yaml
+++ b/scenarios/3ctrl_xcpt_splitted-storage/infra.yaml
@@ -1,4 +1,4 @@
-name: 3ctrl-xcpt-splitted-storage
+name: 3ctrl_xcpt_splitted-storage
 profiles:
   install-server:
     arity: 1
@@ -24,8 +24,8 @@ profiles:
           - cloud::storage::rbd::key
       2:
         roles:
-          - cloud::dashboard
           - cloud::loadbalancer
+          - cloud::dashboard
       3:
         roles:
           - cloud::identity
@@ -161,7 +161,6 @@ profiles:
 
 ordered_profiles:
   - install-server
-  - load-balancer
   - controller
   - compute
   - storage


### PR DESCRIPTION
Fix typo in infra name.

```
Incoherent infra(3ctrl-xcpt-splitted-storage) and env(3ctrl_xcpt_splitted-storage)
```