### PR TITLE
infra.yml: Missing spec param on IS

### DIFF
--- a/scenarios/2nodes/infra.yaml
+++ b/scenarios/2nodes/infra.yaml
@@ -12,6 +12,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   controller:
     arity: 1
     edeploy: openstack-full

--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -9,6 +9,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   controller:
     arity: 3+2n
     edeploy: openstack-full

--- a/scenarios/3ctrl_xcpt/infra.yaml
+++ b/scenarios/3ctrl_xcpt/infra.yaml
@@ -9,6 +9,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   controller:
     arity: 3
     edeploy: openstack-full

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -12,6 +12,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   openstack-full:
     arity: 3
     edeploy: openstack-full

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -9,6 +9,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   openstack-full:
     arity: 3
     edeploy: openstack-full

--- a/scenarios/ref-arch-packed/infra.yaml
+++ b/scenarios/ref-arch-packed/infra.yaml
@@ -9,6 +9,7 @@ profiles:
           - cloud::install::puppetdb::server
     serverspec_config:
       puppetdb_server: puppetdb_server
+      vip_public: vip_public_fqdn
   lb-controller:
     arity: 3+2n
     edeploy: openstack-full

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -7,6 +7,8 @@ profiles:
       1:
         roles:
           - cloud::install::puppetdb::server
+    serverspec_config:
+      vip_public: vip_public_fqdn
   load-balancer:
     arity: 2+n
     edeploy: openstack-full


### PR DESCRIPTION
The install-server profile runs base serverspec test :

https://github.com/enovance/openstack-serverspec/blob/master/spec/tests/base/base_spec.rb#L12-L14

But the variable vip_public is not set on this profile like on compute, etc..

```
install-server:
/usr/bin/ruby -S rspec spec/base/base_spec.rb spec/puppetdb_server/puppetdb_server_spec.rb spec/redis_server/redis_server_spec.rb -t ~host:install-server.domain.org
Run options: exclude {:host=>"install-server.domain.org"}
.........

Top 9 slowest examples (0.17653 seconds, 100.0% of total time):
  Command "timeout 1 dig " should return exit status 0
    0.0402 seconds ./spec/tests/base/base_spec.rb:13
```

And the command should be :
```
  Command "timeout 1 dig os.domain.org" should return exit status 0
```
