### PR TITLE
common.yaml.tmpl: fix declaration osd disk journal and journalsize

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -485,9 +485,11 @@ ceph_mon_secret: {{ config.ceph_mon_secret }}
 {% if config.ceph_osd_devices %}
 ceph_osd_devices:
 {% if config.ceph_osd_devices is mapping %}
-{% for disk in config.ceph_osd_devices %} {{ disk }}:{% if disk.journal is defined %}
-    {{ disk.journal }}
-{% endif %}
+{% for disk, values in config.ceph_osd_devices.iteritems() %}
+  {{ disk }}:
+{% for key, value in values.iteritems() %}
+    {{ key }}: {{ value }}
+{% endfor %}
 {% endfor %}
 {% else %}
 {% for disk in config.ceph_osd_devices %} - {{ disk }}


### PR DESCRIPTION
Bug in "Allow to dedicate a journal by OSD."

From https://github.com/enovance/openstack-yaml-infra/pull/3, this commit introduce a feature to add OSD on different path but don't work.

The change allow to use also journalsize.

Thanks to @dsavineau , @goldyfruit, @nhicher and @TristanCacqueray