### PR TITLE
data/common.yaml.tmpl: permit to overload ceph_public_network

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -478,7 +478,7 @@ ceilometer::agent::central::coordination_url: {{ config.ceilometer_coordination_
 {% endif %}
 
 # Ceph
-ceph_public_network: {{ config.ceph_public_network | default('"%{hiera(\'public_network\')}"') }}
+ceph_public_network: {{ config.ceph_public_network | default('"%{hiera(\'storage_network\')}"') }}
 ceph_cluster_network: "%{hiera('storage_network')}"
 ceph_fsid: {{ config.ceph_fsid | default('') }}
 ceph_mon_secret: {{ config.ceph_mon_secret }}

--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -479,7 +479,6 @@ ceilometer::agent::central::coordination_url: {{ config.ceilometer_coordination_
 
 # Ceph
 ceph_public_network: {{ config.ceph_public_network | default('"%{hiera(\'public_network\')}"') }}
-
 ceph_cluster_network: "%{hiera('storage_network')}"
 ceph_fsid: {{ config.ceph_fsid | default('') }}
 ceph_mon_secret: {{ config.ceph_mon_secret }}

--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -478,7 +478,8 @@ ceilometer::agent::central::coordination_url: {{ config.ceilometer_coordination_
 {% endif %}
 
 # Ceph
-ceph_public_network: "%{hiera('public_network')}"
+ceph_public_network: {{ config.ceph_public_network | default('"%{hiera(\'public_network\')}"') }}
+
 ceph_cluster_network: "%{hiera('storage_network')}"
 ceph_fsid: {{ config.ceph_fsid | default('') }}
 ceph_mon_secret: {{ config.ceph_mon_secret }}


### PR DESCRIPTION
By default, ceph_public_network use public_network. If storage node doesn't access to public_network, I need to overload this param.

Thanks to @goldyfruit and @nhicher 