### PR TITLE
Scenarios: Tie Cinder tests to cloud::volume::api so that we can disable Cinder

### DIFF
--- a/scenarios/2nodes/infra.yaml
+++ b/scenarios/2nodes/infra.yaml
@@ -127,6 +127,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server

--- a/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
+++ b/scenarios/3ctrl_3networker_Xcpt_cephless/infra.yaml
@@ -138,5 +138,6 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::install::puppetdb::server: puppetdb_server
   cloud::install::puppetdb::config: puppetdb_config

--- a/scenarios/3ctrl_xcpt/infra.yaml
+++ b/scenarios/3ctrl_xcpt/infra.yaml
@@ -124,6 +124,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server

--- a/scenarios/3nodes/infra.yaml
+++ b/scenarios/3nodes/infra.yaml
@@ -104,6 +104,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server

--- a/scenarios/3nodes_cephless/infra.yaml
+++ b/scenarios/3nodes_cephless/infra.yaml
@@ -95,6 +95,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server

--- a/scenarios/ref-arch-packed/infra.yaml
+++ b/scenarios/ref-arch-packed/infra.yaml
@@ -130,6 +130,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server

--- a/scenarios/ref-arch/infra.yaml
+++ b/scenarios/ref-arch/infra.yaml
@@ -171,6 +171,7 @@ serverspec:
   cloud::compute::hypervisor: compute
   cloud::compute::api: controller
   cloud::dashboard: dashboard
+  cloud::volume::api: volume_controller
   cloud::object::controller: object_proxy
   cloud::object::storage: object_storage
   cloud::install::puppetdb::server: puppetdb_server


### PR DESCRIPTION
Tied to https://github.com/enovance/openstack-serverspec/pull/73
