### PR TITLE
common.yaml: Fix array value for Cinder backend.

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -342,7 +342,11 @@ volume_cinder_backends:
   {% for type, spec in desc.iteritems() %}
     {{ type }}:
     {% for key, value in spec.iteritems() %}
+      {% if value is string %}
       {{ key }}: '{{ value }}'
+      {% else %}
+      {{ key }}: {{ value }}
+      {% endif %}
     {% endfor %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
When using a cinder backend with parameters requiring an array value we have a
malformed common yaml file because we have multiple simple quotes.

This patch forces the simple quotes only if the value is a string.

Close #58 