### PR TITLE
Always place the galera master-node at the end of list

### DIFF
--- a/files/etc/ansible/hosts.tmpl
+++ b/files/etc/ansible/hosts.tmpl
@@ -1,7 +1,17 @@
 # file: hosts
 
+{% set master = [False] %}
 {% for prof in profiles %}
 [{{ prof }}]
-{% for hname in hosts %}{% if hosts[hname].profile == prof %}
-{{ hname }}.{{ config.domain  }}{% endif %}{% endfor %}
+{% for hname in hosts %}
+{% if hosts[hname].profile == prof and hname != config.galera_master_name %}
+{{ hname }}.{{ config.domain  }}
+{% else %}
+{% set _ = master.append(not master.pop()) %}
+{% endif %}
+{% endfor %}
+{% if master[0] %}
+{{ config.galera_master_name }}.{{ config.domain }}
+{% set _ = master.append(not master.pop()) %}
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
The goal here is to ensure the galera master node will be the last of
the list if is referenced in a profile. We need to be sure master is the last
occurence to handle correctly the upgrade via Ansible :
https://github.com/enovance/edeploy-roles/blob/master/upgrade/I.1.3.0/J.1.0.0/roles/controller/tasks/main.yml#L99-L102