### PR TITLE
common.yaml.tmpl: Use endpoint_public_protocol for nova_metadata_proto

### DIFF
--- a/data/common.yaml.tmpl
+++ b/data/common.yaml.tmpl
@@ -668,7 +668,7 @@ neutron_veth_mtu: {{ config.neutron_veth_mtu | default('1500') }}
 neutron_dnsmasq_dns_servers: {{ config.neutron_dnsmasq_dns_servers | default('false') }}
 
 neutron_metadata_enabled: {{ config.neutron_metadata_enabled | default('true') }}
-nova_metadata_proto: {{ config.nova_metadata_proto | default('http') }}
+nova_metadata_proto: {{ config.nova_metadata_proto | default('"%{hiera(\'endpoint_public_protocol\')}"') }}
 neutron_external_int: {{ config.neutron_external_int | default('"%{hiera(\'external_netif\')}"') }}
 neutron_external_bridge: {{ config.neutron_external_bridge | default('br-pub') }}
 neutron_manage_external_network: {{ config.neutron_manage_external_network | default('false') }}


### PR DESCRIPTION
Since https is fully supported for nova metadata we don't need anymore to
set http as default value for nova_metadata_proto.
We can now use by default the value defined in endpoint_public_protocol.