### PR TITLE
type.yaml.tmpl: Fix nova vncproxy protocol

### DIFF
--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -133,6 +133,7 @@ cloud::compute::api::pacemaker_enabled: "%{hiera('cluster_pacemaker_enabled')}"
 
 cloud::compute::consoleproxy::api_eth: "%{hiera('api_eth')}"
 cloud::compute::consoleproxy::console: "%{hiera('nova_console')}"
+cloud::compute::consoleproxy::protocol: "%{hiera('ks_console_public_proto')}"
 cloud::compute::consoleproxy::spice_port: "%{hiera('spice_port')}"
 cloud::compute::consoleproxy::novnc_port: "%{hiera('novnc_port')}"
 cloud::compute::consoleproxy::secure: "%{hiera('spice_secure')}"


### PR DESCRIPTION
https://review.openstack.org/#/c/190464/ introduced a new parameter for
nova::vncproxy with a default value set to http.
To be able to configure vncproxy with https we need to add also a new
parameter in cloud::compute::consoleproxy