### PR TITLE
type.yaml.tmpl: Fix nova vncproxy params

### DIFF
--- a/data/type.yaml.tmpl
+++ b/data/type.yaml.tmpl
@@ -141,6 +141,10 @@ cloud::compute::consoleproxy::firewall_settings: "%{hiera('firewall_common_extra
 
 cloud::compute::scheduler::scheduler_default_filters: "%{hiera('nova_scheduler_default_filters')}"
 
+nova::vncproxy::common::vncproxy_host: "%{hiera('ks_console_public_host')}"
+nova::vncproxy::common::vncproxy_protocol: "%{hiera('ks_console_public_proto')}"
+nova::vncproxy::common::vncproxy_port: "%{hiera('novnc_port')}"
+
 #
 # cloud::dashboard
 #


### PR DESCRIPTION
The commit 856f1c8ca06108992f1d3c22106f1d26a5b5b93a was not enough to
configure novnc_base_url depending on the architure of controller/compute
nodes.
With this patch we are sure to have the same configuration on controller and
compute and not depending on nova::compute and nova::vncproxy parameters.